### PR TITLE
Poppler version fix

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -30,6 +30,10 @@ if [ "$(uname -m)" = "ppc64le" ]; then
   cp -Rn powerpc64le-conda-linux-gnu/* powerpc64le-conda_cos7-linux-gnu/. || true
   cp -Rn powerpc64le-conda_cos7-linux-gnu/* powerpc64le-conda-linux-gnu/. || true
   popd
+elif [ "$(uname -m)" = "s390x" ]; then
+  with_poppler="no"
+else
+  with_poppler="yes"
 fi
 
 export PKG_CONFIG_PATH_FOR_BUILD=$BUILD_PREFIX/lib/pkgconfig
@@ -56,7 +60,7 @@ export PKG_CONFIG_PATH=${PKG_CONFIG_PATH}:${PREFIX}/lib/pkgconfig:${PKG_CONFIG_P
             --with-rsvg=yes \
             --with-expat=yes \
             --with-libgd=yes \
-            --with-poppler=yes \
+            --with-poppler=${with_poppler} \
             --with-freetype2=yes \
             --with-fontconfig=yes \
             --with-pangocairo=yes \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ source:
     folder: ltdl_compat
 
 build:
-  number: 1
+  number: 2
   detect_binary_files_with_prefix: true  # [unix]
   missing_dso_whitelist:         # [linux]
     - '**/libc.so.6'             # [linux]
@@ -110,11 +110,11 @@ requirements:
     - {{ cdt('libxext-devel') }}                          # [linux]
   host:
     # --with-poppler=yes
-    - poppler
+    - poppler 24.09  # [not s390x]
     # --with-expat=yes
     - expat
     # --with-freetype2
-    - freetype
+    - freetype 2.12.1
     # --with-fontconfig=yes
     - fontconfig
     # --with-gts=yes
@@ -158,7 +158,7 @@ requirements:
     - gdk-pixbuf                                          # [unix]
     - fontconfig
     - freetype
-    - poppler
+    - {{ pin_compatible('poppler', max_pin='x.x.x') }}    # [not s390x]
 
 test:
   files:


### PR DESCRIPTION
graphviz 2.50.0

**Destination channel:** defaults

### Links

- [PKG-6110](https://anaconda.atlassian.net/browse/PKG-6110)
- [Upstream repository](https://gitlab.com/graphviz/graphviz/-/tree/2.50.0?ref_type=tags)
- [Upstream changelog/diff](https://gitlab.com/graphviz/graphviz/-/blob/2.50.0/CHANGELOG.md?ref_type=tags)
- Relevant dependency PRs:
  - AnacondaRecipes/postgresql-feedstock#10

### Explanation of changes:

- Rebuild to pin poppler to compatible version


[PKG-6110]: https://anaconda.atlassian.net/browse/PKG-6110?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ